### PR TITLE
Fix dropOffPoints method when city name is not set

### DIFF
--- a/src/Client/TNTClient.php
+++ b/src/Client/TNTClient.php
@@ -56,8 +56,7 @@ class TNTClient implements TNTClientInterface
     public function getDropOffPoints($zipCode, $city = null)
     {
         if (null === $city) {
-            $cities = $this->getCitiesGuide($zipCode);
-            $city = $cities[0]->getName();
+            $city = current($this->getCitiesGuide($zipCode))->getName();
         }
 
         try {

--- a/src/Client/TNTClient.php
+++ b/src/Client/TNTClient.php
@@ -56,7 +56,8 @@ class TNTClient implements TNTClientInterface
     public function getDropOffPoints($zipCode, $city = null)
     {
         if (null === $city) {
-            $city = $this->getCitiesGuide($zipCode)->getName();
+            $cities = $this->getCitiesGuide($zipCode);
+            $city = $cities[0]->getName();
         }
 
         try {


### PR DESCRIPTION
Hi @winzou,

I hope all is fine for you.

The method `getCityGuide` will return an array of cities.
For `getDropOffPoints` : if city name is not set, you'll try to get name using getCityGuide. 

So let's pick automatically the first city owning this zip code.